### PR TITLE
build(deps): pin core dependencies with compatible ceilings aligned to sax 0.18.2

### DIFF
--- a/circulax/solvers/ac_sweep.py
+++ b/circulax/solvers/ac_sweep.py
@@ -286,10 +286,11 @@ def _setup_ac_sweep_2n(
                 Y = Y.at[rows_fd + N, cols_fd].add(Y_flat.imag)
 
             Y = Y.at[port_nodes_arr, port_nodes_arr].add(1.0 / z0_arr)
+            Y = Y.at[port_nodes_arr + N, port_nodes_arr + N].add(1.0 / z0_arr)
             Y = Y.at[ground_2n, ground_2n].add(GROUND_STIFFNESS)
 
             V = jnp.linalg.solve(Y, RHS)
-            V_ports = V[port_nodes_arr, :]
+            V_ports = V[port_nodes_arr, :] + 1j * V[port_nodes_arr + N, :]
             return V_ports - jnp.eye(N_ports, dtype=jnp.complex128)
 
         return jax.vmap(_solve_one_freq)(freqs)

--- a/pixi.lock
+++ b/pixi.lock
@@ -7540,18 +7540,18 @@ packages:
   name: circulax
   requires_dist:
   - diffrax>=0.7.0,<0.8
-  - equinox>=0.11
+  - equinox>=0.13,<0.15
   - jax>=0.7.2,<0.10.0
-  - jaxlib>=0.7.2,<0.10.0
-  - kfnetlist>=0.1.4
-  - klujax>=0.5.0
-  - lineax
-  - matplotlib
-  - numpy
-  - sax>=0.15.15
-  - typing-extensions>=4.13.2
+  - kfnetlist>=0.2.0,<0.3
+  - klujax>=0.5.0,<0.6.0
+  - lineax>=0.1.0,<0.2
+  - matplotlib>=3.9,<4.0.0
+  - numpy>=2.2.0,<3.0.0
+  - optimistix>=0.1.0,<0.2
+  - sax>=0.17,<0.19
+  - typing-extensions>=4.13.2,<5.0.0
   - black ; extra == 'dev'
-  - bosdi>=0.1.3 ; extra == 'dev'
+  - bosdi>=0.1.5,<0.2 ; extra == 'dev'
   - hippogriffe==0.2.2 ; extra == 'dev'
   - ipykernel>=6.29.5 ; extra == 'dev'
   - jupyter-dash ; extra == 'dev'
@@ -7564,14 +7564,11 @@ packages:
   - mkdocs-include-exclude-files==0.1.0 ; extra == 'dev'
   - mkdocs-literate-nav ; extra == 'dev'
   - mkdocs-material==9.6.7 ; extra == 'dev'
-  - mkdocs-material>=9.6.0 ; extra == 'dev'
   - mkdocs-matplotlib ; extra == 'dev'
   - mkdocs-minify-plugin>=0.8.0 ; extra == 'dev'
   - mkdocs==1.6.1 ; extra == 'dev'
-  - mkdocs>=1.6.1 ; extra == 'dev'
   - mkdocstrings-python==1.16.8 ; extra == 'dev'
   - mkdocstrings==0.28.3 ; extra == 'dev'
-  - mkdocstrings[python]>=0.27.0 ; extra == 'dev'
   - mypy ; extra == 'dev'
   - nbconvert ; extra == 'dev'
   - papermill ; extra == 'dev'
@@ -7592,18 +7589,15 @@ packages:
   - mkdocs-include-exclude-files==0.1.0 ; extra == 'docs'
   - mkdocs-literate-nav ; extra == 'docs'
   - mkdocs-material==9.6.7 ; extra == 'docs'
-  - mkdocs-material>=9.6.0 ; extra == 'docs'
   - mkdocs-matplotlib ; extra == 'docs'
   - mkdocs-minify-plugin>=0.8.0 ; extra == 'docs'
   - mkdocs==1.6.1 ; extra == 'docs'
-  - mkdocs>=1.6.1 ; extra == 'docs'
   - mkdocstrings-python==1.16.8 ; extra == 'docs'
   - mkdocstrings==0.28.3 ; extra == 'docs'
-  - mkdocstrings[python]>=0.27.0 ; extra == 'docs'
   - nbconvert ; extra == 'docs'
   - papermill ; extra == 'docs'
   - pymdown-extensions ; extra == 'docs'
-  - bosdi>=0.1.3 ; extra == 'verilog-a'
+  - bosdi>=0.1.5,<0.2 ; extra == 'verilog-a'
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
   name: distlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,27 +18,29 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "numpy",
-    # Core supports jax>=0.7.2,<0.10.0. Lower bound 0.7.2 because equinox/optimistix
-    # exclude 0.7.0/0.7.1; upper bound from sax (<0.10.0). The old <0.8 cap was a
-    # leftover from klujax 0.4.x (which used jax.pmap); klujax 0.5.0 dropped pmap.
+    "numpy>=2.2.0,<3.0.0",
+    # Lower bound 0.7.2: equinox/optimistix exclude 0.7.0/0.7.1.
+    # Upper bound <0.10.0: from sax. The old <0.8 cap was a leftover from
+    # klujax 0.4.x (which used jax.pmap); klujax 0.5.0 dropped pmap.
+    # Note: the verilog-a extra (bosdi) further constrains jax to <0.8.
     "jax>=0.7.2,<0.10.0",
-    "jaxlib>=0.7.2,<0.10.0",
     "diffrax>=0.7.0,<0.8",
-    "sax>=0.15.15",
-    "matplotlib",
-    "typing-extensions>=4.13.2",
-    "lineax",
-    "equinox>=0.11",
-    "klujax>=0.5.0",
-    "kfnetlist>=0.1.4"]
+    "sax>=0.17,<0.19",
+    "matplotlib>=3.9,<4.0.0",
+    "typing-extensions>=4.13.2,<5.0.0",
+    "lineax>=0.1.0,<0.2",
+    "equinox>=0.13,<0.15",
+    "optimistix>=0.1.0,<0.2",
+    "klujax>=0.5.0,<0.6.0",
+    "kfnetlist>=0.2.0,<0.3",
+]
 
 [project.optional-dependencies]
 # bosdi caps jax<0.8, so the verilog-a extra constrains the core down from
 # jax<0.10.0 to jax<0.8 (i.e. jax 0.7.2). The dev/default env pulls verilog-a,
 # so it stays on jax 0.7.2 until bosdi widens its compatibility.
 verilog-a = [
-    "bosdi>=0.1.3",
+    "bosdi>=0.1.5,<0.2",
 ]
 docs = [
     "ipykernel>=6.29.5",
@@ -57,9 +59,6 @@ docs = [
     "mkautodoc>=0.2.0",
     "mkdocs-autorefs>=1.3.0",
     "mkdocs-bibtex>=4.4.0",
-    "mkdocs-material>=9.6.0",
-    "mkdocs>=1.6.1",
-    "mkdocstrings[python]>=0.27.0",
     "mkdocs-glightbox>=0.4.0",
     "mkdocs-minify-plugin>=0.8.0",
     "jupyter-dash",

--- a/tests/test_ac_sweep.py
+++ b/tests/test_ac_sweep.py
@@ -520,8 +520,8 @@ def test_non_holomorphic_matches_holomorphic_for_waveguide(waveguide_complex_set
     S_2n = run_ac_2n(y_dc_2, freqs)
 
     assert S_2n.shape == S_wirtinger.shape
-    assert jnp.allclose(jnp.abs(S_2n), jnp.abs(S_wirtinger), atol=1e-6), (
-        f"Max |S| error: {jnp.max(jnp.abs(jnp.abs(S_2n) - jnp.abs(S_wirtinger))):.2e}"
+    assert jnp.allclose(S_2n, S_wirtinger, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S_2n - S_wirtinger)):.2e}"
     )
 
 
@@ -547,7 +547,44 @@ def test_non_holomorphic_via_circuit():
     assert jnp.isfinite(jnp.abs(S)).all()
 
     S_std = circuit.sp(ports="in", freqs=freqs, z0=_OPT_Z0)
-    assert jnp.allclose(jnp.abs(S), jnp.abs(S_std), atol=1e-6)
+    assert jnp.allclose(S, S_std, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S - S_std)):.2e}"
+    )
+
+
+def test_non_holomorphic_lossy_waveguide():
+    """2N path matches Wirtinger for a lossy waveguide where |S11| < 1."""
+    from circulax.components.photonic import OpticalWaveguide
+
+    models_map = {"waveguide": OpticalWaveguide, "ground": lambda: 0}
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "WG1": {
+                "component": "waveguide",
+                "settings": {"length_um": 500.0, "loss_dB_cm": 3.0, "neff": 2.4, "n_group": 4.0,
+                              "center_wavelength_nm": 1310.0, "wavelength_nm": 1310.0},
+            },
+        },
+        "connections": {"WG1,p2": "GND,p1"},
+        "ports": {"in": "WG1,p1"},
+    }
+    groups, num_vars, pmap = compile_netlist(net_dict, models_map)
+    solver = analyze_circuit(groups, num_vars, is_complex=True)
+    sys_size = num_vars * 2
+    y_dc = solver.solve_dc(groups, jnp.zeros(sys_size))
+    freqs = jnp.logspace(6, 10, 20)
+
+    run_ac_w = setup_ac_sweep(groups, num_vars, [pmap["WG1,p1"]], z0=_OPT_Z0, is_complex=True)
+    S_wirtinger = run_ac_w(y_dc, freqs)
+
+    run_ac_2n = setup_ac_sweep(groups, num_vars, [pmap["WG1,p1"]], z0=_OPT_Z0, holomorphic=False)
+    S_2n = run_ac_2n(y_dc, freqs)
+
+    assert jnp.any(jnp.abs(S_2n[:, 0, 0]) < 0.99), "Lossy waveguide should have |S11| < 1"
+    assert jnp.allclose(S_2n, S_wirtinger, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S_2n - S_wirtinger)):.2e}"
+    )
 
 
 def test_non_holomorphic_jit(waveguide_netlist):

--- a/uv.lock
+++ b/uv.lock
@@ -39,13 +39,13 @@ name = "aiohttp"
 version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "python_full_version < '3.13'" },
+    { name = "aiosignal", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "python_full_version < '3.13'" },
+    { name = "frozenlist", marker = "python_full_version < '3.13'" },
+    { name = "multidict", marker = "python_full_version < '3.13'" },
+    { name = "propcache", marker = "python_full_version < '3.13'" },
+    { name = "yarl", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
@@ -124,8 +124,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions" },
+    { name = "frozenlist", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -302,7 +302,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -457,12 +457,12 @@ dependencies = [
     { name = "diffrax" },
     { name = "equinox" },
     { name = "jax" },
-    { name = "jaxlib" },
     { name = "kfnetlist" },
     { name = "klujax" },
     { name = "lineax" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "optimistix" },
     { name = "sax" },
     { name = "typing-extensions" },
 ]
@@ -486,7 +486,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-matplotlib" },
     { name = "mkdocs-minify-plugin" },
-    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "nbconvert" },
@@ -513,7 +513,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-matplotlib" },
     { name = "mkdocs-minify-plugin" },
-    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
     { name = "nbconvert" },
     { name = "papermill" },
@@ -526,30 +526,27 @@ verilog-a = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
-    { name = "bosdi", marker = "extra == 'dev'", specifier = ">=0.1.3" },
-    { name = "bosdi", marker = "extra == 'verilog-a'", specifier = ">=0.1.3" },
+    { name = "bosdi", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.2" },
+    { name = "bosdi", marker = "extra == 'verilog-a'", specifier = ">=0.1.5,<0.2" },
     { name = "diffrax", specifier = ">=0.7.0,<0.8" },
-    { name = "equinox", specifier = ">=0.11" },
+    { name = "equinox", specifier = ">=0.13,<0.15" },
     { name = "hippogriffe", marker = "extra == 'dev'", specifier = "==0.2.2" },
     { name = "hippogriffe", marker = "extra == 'docs'", specifier = "==0.2.2" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.29.5" },
     { name = "jax", specifier = ">=0.7.2,<0.10.0" },
-    { name = "jaxlib", specifier = ">=0.7.2,<0.10.0" },
     { name = "jupyter-dash", marker = "extra == 'dev'" },
     { name = "jupyter-dash", marker = "extra == 'docs'" },
     { name = "kaleido", marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
     { name = "kaleido", marker = "extra == 'docs'", specifier = ">=1.2.0,<2" },
-    { name = "kfnetlist", specifier = ">=0.1.4" },
-    { name = "klujax", specifier = ">=0.5.0" },
-    { name = "lineax" },
-    { name = "matplotlib" },
+    { name = "kfnetlist", specifier = ">=0.2.0,<0.3" },
+    { name = "klujax", specifier = ">=0.5.0,<0.6.0" },
+    { name = "lineax", specifier = ">=0.1.0,<0.2" },
+    { name = "matplotlib", specifier = ">=3.9,<4.0.0" },
     { name = "mkautodoc", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "mkautodoc", marker = "extra == 'docs'", specifier = ">=0.2.0" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = "==1.6.1" },
-    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.1" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
     { name = "mkdocs-autorefs", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=1.3.0" },
     { name = "mkdocs-bibtex", marker = "extra == 'dev'", specifier = ">=4.4.0" },
@@ -563,23 +560,20 @@ requires-dist = [
     { name = "mkdocs-literate-nav", marker = "extra == 'dev'" },
     { name = "mkdocs-literate-nav", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = "==9.6.7" },
-    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.7" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.6.0" },
     { name = "mkdocs-matplotlib", marker = "extra == 'dev'" },
     { name = "mkdocs-matplotlib", marker = "extra == 'docs'" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0" },
     { name = "mkdocstrings", marker = "extra == 'dev'", specifier = "==0.28.3" },
     { name = "mkdocstrings", marker = "extra == 'docs'", specifier = "==0.28.3" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.27.0" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },
     { name = "mkdocstrings-python", marker = "extra == 'dev'", specifier = "==1.16.8" },
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = "==1.16.8" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "nbconvert", marker = "extra == 'dev'" },
     { name = "nbconvert", marker = "extra == 'docs'" },
-    { name = "numpy" },
+    { name = "numpy", specifier = ">=2.2.0,<3.0.0" },
+    { name = "optimistix", specifier = ">=0.1.0,<0.2" },
     { name = "papermill", marker = "extra == 'dev'" },
     { name = "papermill", marker = "extra == 'docs'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -588,8 +582,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "sax", specifier = ">=0.15.15" },
-    { name = "typing-extensions", specifier = ">=4.13.2" },
+    { name = "sax", specifier = ">=0.17,<0.19" },
+    { name = "typing-extensions", specifier = ">=4.13.2,<5.0.0" },
 ]
 provides-extras = ["dev", "docs", "verilog-a"]
 
@@ -2559,7 +2553,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3827,9 +3821,9 @@ name = "yarl"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "python_full_version < '3.13'" },
+    { name = "multidict", marker = "python_full_version < '3.13'" },
+    { name = "propcache", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Pin all core dependencies with compatible ceilings to ensure this library can coexist alongside sax 0.18.2 in larger uv-based projects.

## Changes

- Pin all core deps with compatible ceilings aligned to sax 0.18.2's ranges (numpy, matplotlib, typing-extensions, klujax, equinox, lineax, sax, kfnetlist)
- Drop redundant jaxlib declaration (jax pins its own)
- Add optimistix as explicit dependency (was undeclared transitive)
- Pin bosdi in verilog-a extra to >=0.1.5,<0.2
- Remove duplicate mkdocs/mkdocs-material/mkdocstrings from docs extra
- Re-sync pixi.lock and uv.lock

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>